### PR TITLE
Remove Codebeat from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![Tests](https://github.com/go-music-theory/music-theory/actions/workflows/test.yml/badge.svg)](https://github.com/go-music-theory/music-theory/actions/workflows/test.yml) [![GoDoc](https://godoc.org/gopkg.in/music-theory.v0?status.svg)](https://godoc.org/gopkg.in/music-theory.v0) [![Go Report Card](https://goreportcard.com/badge/gopkg.in/music-theory.v0)](https://goreportcard.com/report/gopkg.in/music-theory.v0) [![codebeat badge](https://codebeat.co/badges/2636c257-5ea9-47dd-8194-871e29178c46)](https://codebeat.co/projects/github-com-go-music-theory-music-theory) [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+[![Tests](https://github.com/go-music-theory/music-theory/actions/workflows/test.yml/badge.svg)](https://github.com/go-music-theory/music-theory/actions/workflows/test.yml) 
+[![GoDoc](https://godoc.org/gopkg.in/music-theory.v0?status.svg)](https://godoc.org/gopkg.in/music-theory.v0) 
+[![Go Report Card](https://goreportcard.com/badge/gopkg.in/music-theory.v0)](https://goreportcard.com/report/gopkg.in/music-theory.v0) 
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 [gopkg.in/music-theory.v0](https://gopkg.in/music-theory.v0)
 


### PR DESCRIPTION
It's been shut down.

Also:
- Improve README.md badge formatting
- Split badge links into separate lines for readability.